### PR TITLE
Fix empty response handling in get_all_buckets

### DIFF
--- a/APSToolkitPython/src/aps_toolkit/Bucket.py
+++ b/APSToolkitPython/src/aps_toolkit/Bucket.py
@@ -36,6 +36,10 @@ class Bucket:
             raise Exception(response.content)
         data = response.json()
         df = pd.DataFrame(data["items"])
+
+        if df.empty:
+            return df
+        
         milliseconds_since_epoch = df["createdDate"]
         seconds_since_epoch = milliseconds_since_epoch // 1000
         real_date = pd.to_datetime(seconds_since_epoch, unit="s")


### PR DESCRIPTION
Description:
An issue where get_all_buckets fails when the Data Management API returns an empty items list ({'items': []}). Previously, the method attempted to access createdDate, causing a KeyError.

Changes:
Added a check for an empty DataFrame (df.empty) and return it immediately.

Impact:
Prevents errors when the API returns no data.
